### PR TITLE
glue: refresh scripts

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,15 +89,6 @@ parts:
   wayland-launch:
     plugin: dump
     source: wayland-launch
-    override-build: |
-      # The plugs needed to run Wayland. (wayland-launch checks them, setup.sh connects them)
-      # You may add further plugs here if you want these options
-      PLUGS="wayland graphics-core20"
-      sed --in-place "s/%PLUGS%/$PLUGS/g" $SNAPCRAFT_PART_BUILD/bin/wayland-launch
-      sed --in-place "s/%PLUGS%/$PLUGS/g" $SNAPCRAFT_PART_BUILD/bin/setup.sh
-      sed --in-place "s/%SNAP%/$SNAPCRAFT_PROJECT_NAME/g" $SNAPCRAFT_PART_BUILD/bin/wayland-launch
-      sed --in-place "s/%SNAP%/$SNAPCRAFT_PROJECT_NAME/g" $SNAPCRAFT_PART_BUILD/bin/setup.sh
-      snapcraftctl build
     stage-packages:
       - inotify-tools
 

--- a/wayland-launch/bin/setup.sh
+++ b/wayland-launch/bin/setup.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -e
 
+SNAP_INSTANCE_NAME="$(readlink -f $0 | cut -f 3 -d /)"
+
 snap_connect_harder() {
   # Note the available slot providers
-  if ! snap connections %SNAP% | grep --quiet "^content.*%SNAP%:$1.*$"; then
+  if ! snap connections ${SNAP_INSTANCE_NAME} | grep --quiet "^content.*${SNAP_INSTANCE_NAME}:$1.*$"; then
     available_providers="$(snap interface "$1" | sed -e '1,/slots:/d')"
   else
     available_providers="$(snap interface content | sed -e '1,/slots:/d' | grep "$1")"
@@ -13,7 +15,7 @@ snap_connect_harder() {
   if [ "wayland" = "$1" ]; then
     for PROVIDER in ubuntu-frame mir-kiosk; do
        if echo "$available_providers" | grep --quiet "\- ${PROVIDER}"; then
-         sudo snap connect "%SNAP%:$1" "${PROVIDER}:$1"
+         sudo snap connect "${SNAP_INSTANCE_NAME}:$1" "${PROVIDER}:$1"
          return 0
        fi
     done
@@ -22,8 +24,8 @@ snap_connect_harder() {
   echo "Warning: Failed to connect '$1'. Please connect manually, available providers are:\n$available_providers"
 }
 
-for PLUG in %PLUGS%; do
-  if ! snap connections %SNAP% | grep --quiet "^.*%SNAP%:${PLUG}.*${PLUG}.*$"; then
-    sudo snap connect "%SNAP%:${PLUG}" 2> /dev/null || snap_connect_harder ${PLUG}
+for PLUG in wayland graphics-core20; do
+  if ! snap connections ${SNAP_INSTANCE_NAME} | grep --quiet "^.*${SNAP_INSTANCE_NAME}:${PLUG}.*${PLUG}.*$"; then
+    sudo snap connect "${SNAP_INSTANCE_NAME}:${PLUG}" 2> /dev/null || snap_connect_harder ${PLUG}
   fi
 done

--- a/wayland-launch/bin/wayland-launch
+++ b/wayland-launch/bin/wayland-launch
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 
-for PLUG in %PLUGS%; do
+for PLUG in wayland graphics-core20; do
   if ! snapctl is-connected ${PLUG}
   then
-    echo "WARNING: ${PLUG} interface not connected! Please run: /snap/%SNAP%/current/bin/setup.sh"
+    echo "WARNING: ${PLUG} interface not connected! Please run: /snap/${SNAP_INSTANCE_NAME}/current/bin/setup.sh"
   fi
 done
 


### PR DESCRIPTION
To support parallel installs for `checkbox-mir.snaps`.